### PR TITLE
Remove unnecessary mavenCentral from plugin config

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        mavenCentral()
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
I don't know why was that there, and gradlePluginPortal does include that too.