### PR TITLE
Remove build test on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           17,    # Current Java LTS & minimum supported by Minecraft
         ]
         # and run on both Linux and Windows
-        os: [ubuntu-22.04, windows-2022]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository


### PR DESCRIPTION
- It's Kotlin:JVM, it should have cross-platform support out-of box
- Who wants to run this on Windows anyway?!
- Tests are slow and often failing on Windows for *unknown reasons*
- Hardly the only thing it could catch is a build-time only filename case sensitivity issue