### PR TITLE
Update jdk

### DIFF
--- a/buildSrc/src/main/kotlin/vikbot.compile.gradle.kts
+++ b/buildSrc/src/main/kotlin/vikbot.compile.gradle.kts
@@ -1,6 +1,6 @@
 import org.gradle.kotlin.dsl.kotlin
 
-val targetJavaVersion = 17
+val targetJavaVersion = 21
 
 plugins {
     java


### PR DESCRIPTION
With Kotlin 1.9.20, we can finally target java 21