### PR TITLE
Build action refactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,8 @@ jobs:
   build:
     strategy:
       matrix:
-        # Use these Java versions
-        java: [
-          17,    # Current Java LTS & minimum supported by Minecraft
-        ]
         # and run on both Linux and Windows
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
@@ -25,7 +21,7 @@ jobs:
       - name: setup jdk ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 21
           distribution: 'temurin'
           cache: 'gradle'
       - name: make gradle wrapper executable
@@ -41,7 +37,7 @@ jobs:
             :bot
         continue-on-error: true
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '17' }} # Only upload artifacts built from latest java on one OS
+        if: ${{ matrix.os == 'ubuntu-latest' }} # Only upload artifacts built from latest java on one OS
         uses: actions/upload-artifact@v3
         with:
           name: Artifacts


### PR DESCRIPTION
- remove java version from matrix, we're working on latest anyway
- re-add windows build to catch some unlikely bugs, but it won't be required for merge due to its reliability issues