### PR TITLE
Fix Dependabot alert #5

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
     implementation(libs.kotlinx.coroutines.core)
 
+    implementation(libs.okio) // explicitly implement okio
 
     implementation(libs.slf4j)
     implementation(libs.slf4k)


### PR DESCRIPTION
fix for https://github.com/Populus-Omnibus/vikbot.kt/security/dependabot/5


Explicitly declare okio dependency for API module