### PR TITLE
Fix logger timeformat

### DIFF
--- a/api/src/main/kotlin/io/github/populus_omnibus/vikbot/api/JDAExtension.kt
+++ b/api/src/main/kotlin/io/github/populus_omnibus/vikbot/api/JDAExtension.kt
@@ -1,7 +1,13 @@
 package io.github.populus_omnibus.vikbot.api
 
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toKotlinInstant
+import kotlinx.datetime.toLocalDateTime
 import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.entities.channel.attribute.IGuildChannelContainer
+import java.time.OffsetDateTime
+import java.time.format.TextStyle
 import java.util.*
 import kotlin.reflect.KProperty
 
@@ -19,4 +25,3 @@ val User.isMe: Boolean
 
 val User.isNotMe: Boolean
     get() = !isMe
-

--- a/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/BotConfig.kt
+++ b/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/BotConfig.kt
@@ -23,6 +23,7 @@ data class BotConfig(
     val vikAuthFernet: String,
     var vikAuthChannel: Long? = null, // the only option which can be changed in runtime
     val useRoleTags: Boolean = true,
+    val activeTimeZone: String = "UTC", // CET for Hungary
     val database: DatabaseAccess = DatabaseAccess(),
 ) {
 

--- a/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/Util.kt
+++ b/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/Util.kt
@@ -2,9 +2,12 @@ package io.github.populus_omnibus.vikbot.bot
 
 import io.github.populus_omnibus.vikbot.VikBotHandler
 import kotlinx.datetime.*
+import kotlinx.datetime.TimeZone
 import net.dv8tion.jda.api.entities.Member
 import java.time.OffsetDateTime
 import java.time.ZoneId
+import java.time.format.TextStyle
+import java.util.*
 
 val Member?.isBotAdmin: Boolean
     get() = this?.roles?.any { it.idLong == VikBotHandler.config.adminId } ?: false
@@ -39,3 +42,17 @@ fun String.chunked(maxSize: Int): Sequence<String> = sequence {
     }
     yield(substring(index))
 }
+
+
+
+private val activeTimeZone by lazy { TimeZone.of(VikBotHandler.config.activeTimeZone) }
+
+val Instant.localString
+    get() = this.toLocalDateTime(activeTimeZone).run { "${dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)}, $dayOfMonth ${month.getDisplayName(
+        TextStyle.SHORT, Locale.ENGLISH)} $year $hour:$minute" }
+
+val java.time.Instant.localString
+    get() = this.toKotlinInstant().localString
+
+val OffsetDateTime.localString
+    get() = this.toInstant().localString

--- a/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/modules/msgLogger/MessageLogger.kt
+++ b/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/modules/msgLogger/MessageLogger.kt
@@ -4,6 +4,7 @@ import io.github.populus_omnibus.vikbot.VikBotHandler
 import io.github.populus_omnibus.vikbot.api.EventResult
 import io.github.populus_omnibus.vikbot.api.annotations.Module
 import io.github.populus_omnibus.vikbot.api.isNotMe
+import io.github.populus_omnibus.vikbot.bot.localString
 import io.github.populus_omnibus.vikbot.db.*
 import kotlinx.datetime.Clock
 import net.dv8tion.jda.api.EmbedBuilder
@@ -85,7 +86,7 @@ object MessageLogger {
         }
         return EmbedBuilder().apply {
             setAuthor(userName, null, iconUrl)
-            setFooter(Clock.System.now().toString())
+            setFooter(Clock.System.now().localString)
             setDescription("""
                     **<@$author> $title ${link?.let { "[message]($it)" } ?: "message"}**
                     $contentRaw

--- a/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/modules/report/ReportForm.kt
+++ b/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/modules/report/ReportForm.kt
@@ -5,12 +5,12 @@ import io.github.populus_omnibus.vikbot.api.EventResult
 import io.github.populus_omnibus.vikbot.api.annotations.Module
 import io.github.populus_omnibus.vikbot.api.commands.SlashCommand
 import io.github.populus_omnibus.vikbot.api.commands.SlashOptionType
-import io.github.populus_omnibus.vikbot.api.commands.administrator
 import io.github.populus_omnibus.vikbot.api.commands.operator
 import io.github.populus_omnibus.vikbot.api.createMemory
 import io.github.populus_omnibus.vikbot.api.interactions.IdentifiableInteractionHandler
 import io.github.populus_omnibus.vikbot.api.maintainEvent
 import io.github.populus_omnibus.vikbot.api.plusAssign
+import io.github.populus_omnibus.vikbot.bot.localString
 import io.github.populus_omnibus.vikbot.bot.prettyPrint
 import io.github.populus_omnibus.vikbot.bot.toUserTag
 import io.github.populus_omnibus.vikbot.db.Servers
@@ -98,7 +98,7 @@ object ReportForm {
                         setDescription("**${reportedUser.idLong.toUserTag()} had their [message](${message.jumpUrl}) reported**")
                         addField("Content", message.contentRaw, false)
                         addField("Reason", reason, false)
-                        addField("Sent at", message.timeCreated.prettyPrint(true), false)
+                        addField("Sent at", message.timeCreated.localString, false)
                         addField("Reported by", reporter.idLong.toUserTag(), false)
                         setFooter(Clock.System.now().prettyPrint())
                         reportedMessage.attachments.filter { it.isImage }.getOrNull(0)?.let {

--- a/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/modules/rss/RssModule.kt
+++ b/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/modules/rss/RssModule.kt
@@ -4,6 +4,7 @@ import com.prof18.rssparser.RssParser
 import com.prof18.rssparser.model.RssItem
 import io.github.populus_omnibus.vikbot.VikBotHandler
 import io.github.populus_omnibus.vikbot.api.annotations.Module
+import io.github.populus_omnibus.vikbot.bot.localString
 import io.github.populus_omnibus.vikbot.db.DiscordGuild
 import io.github.populus_omnibus.vikbot.db.DiscordGuilds
 import io.github.populus_omnibus.vikbot.db.RssFeeds
@@ -13,8 +14,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel
 import org.jetbrains.exposed.sql.select
@@ -22,8 +21,6 @@ import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.slf4j.kotlin.getLogger
 import org.slf4j.kotlin.info
-import java.time.format.TextStyle
-import java.util.*
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
@@ -107,8 +104,6 @@ object RssModule {
         }
     }
 
-    private val Instant.localString
-        get() = this.toLocalDateTime(TimeZone.of("CET")).run { "${dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)}, $dayOfMonth ${month.getDisplayName(TextStyle.SHORT, Locale.ENGLISH)} $year $hour:$minute" }
 }
 
 data class RssFeedObject(


### PR DESCRIPTION
Use the same datetime format and configurable timezone for all time convertions.

Closes #98 