### PR TITLE
Fix not deleted handled voice channels

### DIFF
--- a/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/modules/voiceHandler/VoiceHandlerModule.kt
+++ b/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/modules/voiceHandler/VoiceHandlerModule.kt
@@ -53,9 +53,9 @@ object VoiceHandlerModule {
                             val channel = event.guild.getChannelById(VoiceChannel::class.java, chId)
                             if (channel != null && channel.members.isEmpty()) {
                                 channel.delete().complete()
-                            }
-                            transaction {
-                                tmpChannel.delete()
+                                transaction {
+                                    tmpChannel.delete()
+                                }
                             }
                         }
                 }


### PR DESCRIPTION
Only delete a tmp channel from the database, if it was deleted in discord