### PR TITLE
[Security] Fix loopback query

### DIFF
--- a/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/modules/musicPlayer/GuildMusicManager.kt
+++ b/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/modules/musicPlayer/GuildMusicManager.kt
@@ -8,6 +8,7 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import io.github.populus_omnibus.vikbot.bot.modules.musicPlayer.lavaPlayer.AudioPlayerSendHandler
 import io.github.populus_omnibus.vikbot.bot.modules.musicPlayer.lavaPlayer.TrackScheduler
 import io.github.populus_omnibus.vikbot.bot.modules.musicPlayer.lavaPlayer.YtQueryLoadResultHandler
+import io.github.populus_omnibus.vikbot.bot.security.SecureRequestUtil
 import io.github.populus_omnibus.vikbot.db.Servers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.withLock
@@ -60,6 +61,10 @@ class GuildMusicManager(
         const val EMPTY_QUEUE_TIMEOUT = 60000L
         private var playerManager: AudioPlayerManager = DefaultAudioPlayerManager().apply {
             AudioSourceManagers.registerRemoteSources(this)
+
+            this.setHttpBuilderConfigurator { request ->
+                SecureRequestUtil.configureSecurely(request)
+            }
         }
 
         fun clampVolume(volume: Int) = volume.coerceIn(0, ABSOLUTE_MAX_VOLUME)

--- a/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/modules/musicPlayer/MusicPlayerCommands.kt
+++ b/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/modules/musicPlayer/MusicPlayerCommands.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.datetime.Clock
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
-import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.slf4j.kotlin.getLogger
 import kotlin.collections.set
@@ -24,8 +23,6 @@ import kotlin.time.Duration.Companion.milliseconds
 object MusicPlayerCommands : CommandGroup("music", "Music player") {
     internal val logger by getLogger()
     private val managerInstances: MutableMap<Long, GuildMusicManager> = mutableMapOf()
-
-    val hostFilter = Regex("^(localhost|(127.\\d.\\d.\\d)|::1)\$")
 
     @Module
     fun init(bot: VikBotHandler) {
@@ -145,7 +142,7 @@ object MusicPlayerCommands : CommandGroup("music", "Music player") {
         val manager = managerGet(event) ?: return
         event.deferReply().setEphemeral(true).complete()
         val track = manager.queryAudio(query,
-            query.toHttpUrlOrNull()?.sanitizeUrl()?.let { GuildMusicManager.MusicQueryType.RawURL } ?: GuildMusicManager.MusicQueryType.YouTubeSearch)
+            query.toHttpUrlOrNull()?.let { GuildMusicManager.MusicQueryType.RawURL } ?: GuildMusicManager.MusicQueryType.YouTubeSearch)
         if (track == null) {
             event.hook.editOriginal("Could not find track").complete()
             return
@@ -153,7 +150,5 @@ object MusicPlayerCommands : CommandGroup("music", "Music player") {
         manager.queue(track, isForced)
         event.hook.editOriginal("Queued ${track.info.title}").complete()
     }
-
-    private fun HttpUrl.sanitizeUrl(): HttpUrl? = this.takeUnless { this.host.matches(hostFilter) }
 }
 

--- a/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/security/SecureRequestUtil.kt
+++ b/bot/src/main/kotlin/io/github/populus_omnibus/vikbot/bot/security/SecureRequestUtil.kt
@@ -1,0 +1,76 @@
+package io.github.populus_omnibus.vikbot.bot.security
+
+import com.sedmelluq.discord.lavaplayer.tools.http.ExtendedConnectionOperator
+import com.sedmelluq.discord.lavaplayer.tools.http.ExtendedHttpClientBuilder
+import org.apache.http.config.Registry
+import org.apache.http.conn.DnsResolver
+import org.apache.http.conn.socket.ConnectionSocketFactory
+import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager
+import org.apache.http.impl.conn.SystemDefaultDnsResolver
+import org.slf4j.kotlin.getLogger
+import org.slf4j.kotlin.warn
+import java.lang.invoke.MethodHandles
+import java.net.InetAddress
+import java.util.*
+import java.util.concurrent.TimeUnit
+import kotlin.reflect.full.functions
+import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.jvm.javaMethod
+
+object SecureRequestUtil : DnsResolver {
+    private val logger by getLogger()
+
+    private var builders: IdentityHashMap<ExtendedHttpClientBuilder, Boolean> = IdentityHashMap()
+
+    @Suppress("UNCHECKED_CAST") // I know what I'm doing
+    private val createConnectionSocketFactory: ExtendedHttpClientBuilder.() -> Registry<ConnectionSocketFactory> by lazy {
+
+        // First, the method descriptor
+        val method = ExtendedHttpClientBuilder::class.functions.find { it.name == "createConnectionSocketFactory" }!!
+        method.isAccessible = true // here's the problem
+
+        // Unreflect our private method
+        val handle = MethodHandles.privateLookupIn(ExtendedHttpClientBuilder::class.java, MethodHandles.lookup())
+            .unreflectSpecial(method.javaMethod, ExtendedHttpClientBuilder::class.java)
+
+        return@lazy { // Kotlin lambda is required for proper JVM signature
+            handle(this) as Registry<ConnectionSocketFactory> // create an invoker for this
+        }
+    }
+
+    fun configureSecurely(builder: HttpClientBuilder): HttpClientBuilder = builder.apply {
+
+        if (this is ExtendedHttpClientBuilder) {
+            this@SecureRequestUtil.builders += this to true
+            this.setConnectionManagerFactory { operator, connectionFactory ->
+                // More JVM reflection magic
+
+
+                val manager = PoolingHttpClientConnectionManager(
+                    ExtendedConnectionOperator(createConnectionSocketFactory(), null, this@SecureRequestUtil),
+                    connectionFactory,
+                    -1,
+                    TimeUnit.MILLISECONDS
+                )
+                manager.maxTotal = 3000
+                manager.defaultMaxPerRoute = 1500
+                manager
+            }
+        }
+
+        this.setDnsResolver(this@SecureRequestUtil)
+
+    }
+
+    override fun resolve(host: String?): Array<InetAddress> {
+        return SystemDefaultDnsResolver.INSTANCE.resolve(host).filter { address ->
+            address.isLoopbackAddress.not().also {
+                if (!it) {
+                    logger.warn { "Trying to resolve loopback address: $address" }
+                }
+            }
+        }.toTypedArray()
+    }
+
+}


### PR DESCRIPTION
Lavaplayer query should never resolve to any loopback address, that could be a security vulnerability.  
The solution is to modify the DNS resolver, and before returning addresses, always remove all loopback entries