### PR TITLE
Revert "Bump kotlinx-exposed from 0.52.0 to 0.54.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ discord-jda = "5.1.0"
 
 junit = "5.11.0"
 
-kotlinx-exposed = "0.54.0"
+kotlinx-exposed = "0.52.0"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
The bug is still in exposed, I'll have to end it myself